### PR TITLE
Add light faces for highlight-stages-mode

### DIFF
--- a/minimal-light-theme.el
+++ b/minimal-light-theme.el
@@ -115,6 +115,13 @@
       ;; hl-line-mode
      `(hl-line ((,class (:background ,hl-background))))
      `(hl-line-face ((,class (:background ,hl-face-background))))
+     
+      ;; highlight-stages-mode
+     `(highlight-stages-negative-level-face ((,class (:foreground ,failure))))
+     `(highlight-stages-level-1-face ((,class (:background ,org-background))))
+     `(highlight-stages-level-2-face ((,class (:background ,region))))
+     `(highlight-stages-level-3-face ((,class (:background ,region))))
+     `(highlight-stages-higher-level-face ((,class (:background ,region))))
 
      ;; org-mode
      `(org-level-1 ((,class (:foreground ,foreground :height 1.6))))


### PR DESCRIPTION
I added some faces in the light variant for [highlight-stages](https://github.com/zk-phi/highlight-stages). I'm not exactly sure how it should look, but I thought it would make sense to reduce the differentiation between different levels.

Example text:
```lisp
`(highlight-stages-level-1-face
  `(highlight-stages-level-2-face
    ,highlight-stages-level-1-face
    `(highlight-stages-level-3-face
      ,highlight-stages-level-2-face
      `(highlight-stages-higher-level-face
        ,highlight-stages-level-3-face))))

,highlight-stages-negative-level-face
```

![screen shot 2016-06-08 at 11 58 00](https://cloud.githubusercontent.com/assets/850317/15890520/4d65d7ea-2d70-11e6-9396-4f1bc73ab3e8.png)

I'm not sure what to do about the dark variant since I don't like dark themes at all, but let me know if there's something I should do with that. Also, feel free to make or suggest changes; this is only a starting suggestion.